### PR TITLE
Remove dependency on Xorg, libcanberra and bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ Alarm of bad battery for when it is disconnected from power supply due to the ja
 
 Tested on Arch Linux in March/2015. See at [AUR](http://aur.archlinux.org).
 
-**Dependencies:** make, bash, udev, ffmpeg, alsa-utils
+**Dependencies:** make, sh, udev, ffmpeg, alsa-utils

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ Alarm of bad battery for when it is disconnected from power supply due to the ja
 
 Tested on Arch Linux in March/2015. See at [AUR](http://aur.archlinux.org).
 
-**Dependencies:** make, bash, udev, xorg, libcanberra
+**Dependencies:** make, bash, udev, ffmpeg, alsa-utils

--- a/dangerous-jack-connector.sh
+++ b/dangerous-jack-connector.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # The MIT License (MIT)
 #

--- a/dangerous-jack-connector.sh
+++ b/dangerous-jack-connector.sh
@@ -3,6 +3,7 @@
 # The MIT License (MIT)
 #
 # Copyright (c) 2015 Alexandre Magno ‒ alexandre.mbm@gmail.com
+# Copyright (c) 2015 Mattias Andrée ‒ maandree@member.fsf.org
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -23,11 +24,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-export DISPLAY=:0
-
 SOUND="/usr/share/sounds/freedesktop/stereo/suspend-error.oga"
 
 for i in {1..4}
 do
-    canberra-gtk-play --file="$SOUND"
+    ffmpeg -i "$SOUND" -f wav - 2>/dev/null | aplay 2>/dev/null
 done


### PR DESCRIPTION
As per #1, the first commit replace libcanberra with ffmpeg and aplay,
and those also remove the dependency on Xorg.

Additionally, the second commit replaces the dependency on bash with sh.
On most(?) GNU/Linux distributions sh is bash, but it can be any POSIX compatible shell.
